### PR TITLE
Compile improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "tsc && vite build --emptyOutDir",
         "prepare": "husky install",
         "lint": "eslint --fix '**/*.{js,jsx,ts,tsx}'",
         "format": "prettier --write --ignore-unknown '**/*.{json,js,ts,jsx,tsx,html}'",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
     plugins: [react()],
     root: 'devfiles',
     build: {
-        outDir: '../dist'
+        outDir: '../dist',
+        sourcemap: true
     },
     test: {
         environment: 'jsdom',


### PR DESCRIPTION
- emptyOutDir: when building, delete everything in dist, then rebuild. otherwise, when we remove a file, it will stay in the folder
- generate source map: this allows us to use our browsers' debuggers to see the original uncompressed source files. if the final product won't be open source, this will have to be disabled. while debugging, this should stay

(This is related to our build process so I'm requesting from you Geoege)