### PR TITLE
Create `Options` independently of panels

### DIFF
--- a/devfiles/src/classes/options/InputOption.tsx
+++ b/devfiles/src/classes/options/InputOption.tsx
@@ -3,12 +3,13 @@ import Query from '../query/Query';
 
 export default abstract class InputOption {
     public readonly name: string;
-    protected readonly panel: Panel;
-    public constructor(panel: Panel, name: string) {
+    public constructor(name: string) {
         this.name = name;
-        this.panel = panel;
     }
     public abstract query(): Query;
     public abstract render(): JSX.Element[];
     public abstract callback(newValue: any);
+    public static fromPanel(panel: Panel): InputOption {
+        throw new Error('Not implemented, please call fromPanel on a subclass of InputOption');
+    }
 }


### PR DESCRIPTION
So that `Options` are independent of `Panels`, I want to change the way they are implemented.  
This may involve creating a `PanelOption class but it is up to whoever implements the panels to decide. 

This affects the way the `GlobalSidebar` is implemented as I want to use the same `Option` classes but they are not linked to a `Panel`.