### PR TITLE
Implement addCSV to now support multiple files

### DIFF
--- a/devfiles/src/classes/data/Data.test.jsx
+++ b/devfiles/src/classes/data/Data.test.jsx
@@ -57,7 +57,7 @@ describe('Data', async () => {
                     expected: 'Acoustic Classifier Development'
                 },
                 { index: 0, attribute: Attribute.species, expected: 46 },
-                { index: 5, attribute: Attribute.fileName, expected: filename }
+                { index: 5, attribute: Attribute.csvName, expected: filename }
             ])(
                 'get accessor for columns with index $index and attribute $attribute',
                 async ({ index, attribute, expected }) => {

--- a/devfiles/src/classes/data/Data.ts
+++ b/devfiles/src/classes/data/Data.ts
@@ -7,7 +7,7 @@ import SetElement from './setutils/SetElement';
 import ReferenceSet from './setutils/ReferenceSet.ts';
 
 enum Attribute {
-    fileName,
+    csvName = '_FILE',
     recordingFileName = 'RECORDING FILE NAME',
     originalFileName = 'ORIGINAL FILE NAME',
     recordingFilePart = 'ORIGINAL FILE PART',
@@ -39,11 +39,16 @@ class Data {
 
     // 0th element in this array is column 1
     // column 0 is file identifier
+    // all elements are capitalised and the array is duplicate-free
     public columnList: string[] = ['_FILE'];
 
     public readDatabase() {
         return this.sortedDatabase;
     }
+
+    // see the method below to access it
+    private titleToColumnIndex = new Map<string, number>([['_FILE', 0]]);
+    private cellProcessors = [(a) => this.sets[0].addRawOrGet(a)];
 
     // Throws an error message (such as: malformed CSV) to be appended to filename to become "abc.csv: malformed CSV"
     /* eslint no-var: off */
@@ -76,23 +81,13 @@ class Data {
         this.columnList = this.columnList.concat(columnNames);
     }
 
-    // For accessing cell data
     // filename: 0
     public getIndexForColumn(a: Attribute): number {
-        const index = getColumnIndex(a, this.columnList);
-        if (index == -1) {
+        const index = this.columnList.indexOf(a); //this.titleToColumnIndex.get(a);
+        if (index === undefined) {
             throw 'no such column ' + a + ' in ' + this.columnList;
         }
         return index;
-    }
-}
-
-function getColumnIndex(a: Attribute, columnList: string[]): number {
-    switch (a) {
-        case Attribute.fileName:
-            return 0;
-        default:
-            return columnList.indexOf(a);
     }
 }
 

--- a/devfiles/src/classes/data/Data.ts
+++ b/devfiles/src/classes/data/Data.ts
@@ -1,7 +1,7 @@
 /* Don't access data, use DataFilteredAccess */
 
 import normaliseIdentifier from './setutils/FileIdentifierUtil.ts';
-import { /*integrate,*/ processTypes } from './datautils/table_integrate';
+import { integrateNewCSV, processTypes } from './datautils/table_integrate';
 import { parseCSVFromByteArray } from './datautils/csvreader';
 import SetElement from './setutils/SetElement';
 import ReferenceSet from './setutils/ReferenceSet.ts';
@@ -61,29 +61,20 @@ class Data {
             throw 'Malformed CSV ' + e;
         }
 
-        // One function to return processors for columnNames
-        // The other taking columnList and columnNames, giving a list length columnNames with permute lambdas
-        // (Permute: take common rows first, then remaining in order)
-        // A third giving sets and setmakers for new columns
-        // With sets, for older files, need to go through them for older columns so tag them empty
-
-        // Data statistician: what does it take on update? new rows, old rows, columnlist. refresh for rescanning on deleted file
-        // Data taxonomist: updated rows. refresh for rescanning on deleted file
-
-        // One function to take old columnlist, new columnlist, new rows, old rows
-        // permutes new rows, gives new sets, makes processor for old rows internally and processes them (for each element, adds null there)
-
-        // need proper integrate here.
-        this.sets = this.sets.concat(processTypes(columnNames, content));
-        // TODO: proper merge
-        // TODO: sort!!
-        this.sortedDatabase = content;
-        this.columnList = this.columnList.concat(columnNames);
+        integrateNewCSV(
+            this.columnList,
+            this.titleToColumnIndex,
+            columnNames,
+            this.sortedDatabase,
+            content,
+            this.sets,
+            this.cellProcessors
+        );
     }
 
     // filename: 0
     public getIndexForColumn(a: Attribute): number {
-        const index = this.columnList.indexOf(a); //this.titleToColumnIndex.get(a);
+        const index = this.titleToColumnIndex.get(a);
         if (index === undefined) {
             throw 'no such column ' + a + ' in ' + this.columnList;
         }

--- a/devfiles/src/classes/data/DataFilterer.ts
+++ b/devfiles/src/classes/data/DataFilterer.ts
@@ -27,8 +27,11 @@ export default class DataFilterer {
     public constructor(data: Data) {
         this.data = data;
         // Preallocate to max size
-        this.filteredData = Array.from({ length: data.readDatabase().length }, (_, i) => data[i]);
-        this.filteredDataArrLen = data.readDatabase().length;
+        const db = data.readDatabase();
+        this.filteredData = new Array(db.length);
+        for (let i = 0; i < db.length; i++) this.filteredData[i] = data[i];
+
+        this.filteredDataArrLen = db.length;
     }
 
     // currently, this function assumes it won't be called with same args consecutively

--- a/devfiles/src/classes/data/datautils/csvreader.ts
+++ b/devfiles/src/classes/data/datautils/csvreader.ts
@@ -5,7 +5,7 @@ CSV Reader WITH A DIFFERENCE:
 - security analysis: i to always increase, O(n^2) scanning (through findIndex) is avoided
 
 The difference is that this CSV reader adds to the beginning of each row a value passed in as a parameter.
-(Which is the identifier for the file)
+(Which is the identifier for the file, hence the columnNames array returned has the first element _FILE)
 */
 
 import SetElement from '../setutils/SetElement';
@@ -29,7 +29,7 @@ function parseCSV(
 ): { columnNames: string[]; content: (string | SetElement)[][] } {
     const l = input.length;
 
-    const columnNames = [];
+    const columnNames = ['_FILE'];
 
     // An iteration starts from cell beginning and handles up to and including the comma and the newline
     // (but not both, because that would be an empty cell)
@@ -84,7 +84,7 @@ function parseCSV(
             case '\r':
                 // Treat empty lines and empty cells differently
                 i++; // Prepare for the next iteration early
-                if (columnNames.length) {
+                if (columnNames.length > 1) {
                     // Empty cell at the end of line
                     columnNames.push('');
                     break consume_header;
@@ -129,7 +129,7 @@ function parseCSV(
 
     // Set up comma or newline predictor: all rows have the same number of columns,
     // so expect comma except when reading the last column
-    const naturalColumnCount = columnNames.length;
+    const naturalColumnCount = columnNames.length - 1; // -1 due to '_FILE' being the 0th element in the columns array
     //const expectNewlineWhenReadingCell = naturalColumnCount - 2;
 
     // Add a first element to each array

--- a/devfiles/src/classes/data/datautils/table_integrate.ts
+++ b/devfiles/src/classes/data/datautils/table_integrate.ts
@@ -1,21 +1,139 @@
 /* Handles merging multiple files together */
 //import FileIdentifierManager from "../setutils/FileIdentifierManager";
 
-// CSVColumnList is fresh from file
-// columnList, CSVContents is modified, database is modified
-/*function integrate(columnList: string[], database: (string | number)[][], CSVColumnList: string[], CSVContents: string[][], CSVIdentifier: FileIdentifierManager) {
-
-}
-function sortNewFile(db: (string | number)[], compKey: number): (string | number)[] {
-    return [];
-}
-
-// TODO: JS Date conversion first
-function mergeSort(db1: (string | number)[], db2: (string | number)[], compKey: number): (string|number)[] {
-    return [];
-}*/
-
 import ReferenceSet from '../setutils/ReferenceSet';
+
+function matchColumnNames(upperCaseColumnName) {
+    switch (upperCaseColumnName) {
+        case 'SCORE':
+        case 'CONFIDENCE':
+            return 'PROBABILITY';
+        case 'COMMON_NAME': // Underscore, because from bird pipeline CSV
+            return 'ENGLISH NAME';
+        default:
+            return upperCaseColumnName;
+    }
+}
+
+// oldColumnList and newColumnList have 0th element "_FILE"
+// precondition and postcondition: see columnList in Data.ts
+
+// oldColumnList modified: new column names added to it
+// titleToColumnIndex modified: new columns are added to it
+// newColumnList shouldn't be used after this function is called
+// oldDatabase modified: new rows are appended to this. old rows are extended~~
+// newDatabase shouldn't be used after this function is called
+// oldSets modified: new sets appended. older sets now have more elements.
+// oldProcessors modified: extended with new columns
+function integrateNewCSV(
+    oldColumnList: string[],
+    titleToColumnIndex: Map<string, number>,
+    newColumnList: string[],
+    oldDatabase,
+    newDatabase,
+    oldSets: ReferenceSet[],
+    oldProcessors: any[]
+) {
+    const permutes: number[] = new Array(newColumnList.length);
+    permutes[0] = 0;
+    // [0,3,1,undefined] means bring 1st column of new to 3rd of old, second to first of old, make a new column for the third
+    // undefined means "new column"
+    // -2 means "duplicate column, drop it"
+
+    // used for duplicate column detection in the newColumnList
+    const earliestColumnWithNameInNew = new Map<string, number>();
+
+    for (let i = 1; i < newColumnList.length; i++) {
+        newColumnList[i] = matchColumnNames(newColumnList[i].toUpperCase());
+        if (earliestColumnWithNameInNew.get(newColumnList[i]) === undefined) {
+            earliestColumnWithNameInNew.set(newColumnList[i], i);
+            permutes[i] = titleToColumnIndex.get(newColumnList[i]);
+        }
+        // a duplicate
+        else permutes[i] = -2;
+    }
+
+    // Remove duplicate rows
+    const columnsToRemove = [];
+    permutes.forEach((n, i) => {
+        if (n == -2) columnsToRemove.push(i);
+    });
+    if (columnsToRemove.length) {
+        for (let r = 0; r < newDatabase.length; r++) {
+            const ro = newDatabase[r];
+            for (let i = columnsToRemove.length - 1; i >= 0; i--) ro.splice(columnsToRemove[i], 1);
+        }
+        for (let i = columnsToRemove.length - 1; i >= 0; i--) {
+            newColumnList.splice(columnsToRemove[i], 1);
+            permutes.splice(columnsToRemove[i], 1);
+        }
+    }
+
+    // Which columns are new, which are old?
+    // assign undefineds their columns
+    const originalColumnCount = oldColumnList.length;
+    let nextColumn = originalColumnCount;
+    for (let i = 0; i < permutes.length; i++) {
+        if (permutes[i] === undefined) {
+            permutes[i] = nextColumn;
+            oldColumnList.push(newColumnList[i]);
+            titleToColumnIndex.set(newColumnList[i], nextColumn);
+            nextColumn++;
+        }
+    }
+
+    const columnCount = nextColumn;
+    let permutationNeeded = false;
+    // Use originalColumnCount: no need to permutate if only extension needed
+    for (let i = 0; i < originalColumnCount; i++) {
+        if (permutes[i] != i) {
+            permutationNeeded = true;
+            break;
+        }
+    }
+
+    const oldDBLen = oldDatabase.length,
+        newDBLen = newDatabase.length;
+    const finalDBLen = (oldDatabase.length = oldDBLen + newDBLen);
+
+    if (permutationNeeded) {
+        for (let r = 0; r < newDBLen; r++) {
+            const ro = newDatabase[r];
+            const ro2 = (oldDatabase[r + oldDBLen] = new Array(columnCount));
+            for (let i = 0; i < columnCount; i++) ro2[permutes[i]] = ro[i];
+        }
+    } else {
+        for (let r = 0; r < newDBLen; r++) {
+            const ro = newDatabase[r];
+            const ro2 = (oldDatabase[r + oldDBLen] = new Array(columnCount));
+            for (let i = 0; i < columnCount; i++) ro2[i] = ro[i];
+        }
+    }
+
+    // Free memory
+    newDatabase.length = 0;
+    newColumnList.length = 0;
+
+    // Extend processors, process old data
+    // NOTE: NOT IMPLEMENTED: it isn't useful to extend old data with NaN, unknown dates, and SetElement("") and ""
+    // INCONSISTENCY: but we do process empty columns of the new rows (if the new data doesn't have some columns as the original)
+
+    // Extend processors, process new data with both old and new processors
+    // for this, extend set
+
+    const newColumns = oldColumnList.slice(originalColumnCount);
+    const newSets = newColumns.map((a) => (columnNeedsSet(a) ? new ReferenceSet() : undefined));
+    const newProcessors = newColumns.map((n, i) => getProcessorForColumn(n, newSets[i]));
+    oldSets.push(...newSets);
+    oldProcessors.push(...newProcessors);
+    for (let i = oldDBLen; i < finalDBLen; i++) {
+        const r = oldDatabase[i];
+        // Skip file identifier
+        for (i = 1; i < columnCount; i++) {
+            r[i] = newProcessors[i](r[i]);
+        }
+    }
+}
 
 function getProcessorForColumn(columnName, set: ReferenceSet) /*: (cell: string) => any*/ {
     // Make set manager for each row that wants a
@@ -88,6 +206,8 @@ function getProcessorForColumn(columnName, set: ReferenceSet) /*: (cell: string)
 
 function columnNeedsSet(columnName) {
     switch (columnName) {
+        case '_FILE':
+            return true;
         case 'RECORDING FILE NAME':
         case 'ORIGINAL FILE NAME':
         case 'ORIGINAL FILE PART':
@@ -126,7 +246,15 @@ function columnNeedsSet(columnName) {
 // columnNames excludes filename
 /* eslint no-var: off */
 function processTypes(columnNames, content) {
-    columnNames = columnNames.map((x: string) => (x == 'SCORE' ? 'PROBABILITY' : x));
+    columnNames = columnNames.map((x: string) =>
+        x == 'SCORE'
+            ? 'PROBABILITY'
+            : x == 'CONFIDENCE'
+              ? 'PROBABIITY'
+              : x == 'COMMON_NAME'
+                ? 'ENGLISH NAME'
+                : x
+    );
 
     const sets = columnNames.map((a) => (columnNeedsSet(a) ? new ReferenceSet() : undefined));
     const processors = [undefined].concat(
@@ -142,4 +270,4 @@ function processTypes(columnNames, content) {
     return sets;
 }
 
-export { processTypes };
+export { integrateNewCSV, processTypes };

--- a/devfiles/src/classes/data/datautils/table_integrate.ts
+++ b/devfiles/src/classes/data/datautils/table_integrate.ts
@@ -129,8 +129,8 @@ function integrateNewCSV(
     for (let i = oldDBLen; i < finalDBLen; i++) {
         const r = oldDatabase[i];
         // Skip file identifier
-        for (i = 1; i < columnCount; i++) {
-            r[i] = newProcessors[i](r[i]);
+        for (let z = 1; z < columnCount; z++) {
+            r[z] = oldProcessors[z](r[z]);
         }
     }
 }


### PR DESCRIPTION
I also renamed `Attribute.fileName ` from fileName to csvName. Now it distinguishes more from `recordingFileName `, which is parsed from data, than before.

I modified the csv reader to add, as the 0th element, to columnList, _FILE, which was in the contents but not in columns. This helps simplify code.