### PR TITLE
Add queries for time

### DIFF
--- a/devfiles/src/classes/data/Data.ts
+++ b/devfiles/src/classes/data/Data.ts
@@ -5,6 +5,7 @@ import { integrateNewCSV } from './datautils/table_integrate';
 import { parseCSVFromByteArray } from './datautils/csvreader';
 import SetElement from './setutils/SetElement';
 import ReferenceSet from './setutils/ReferenceSet.ts';
+import DataStats from './DataStats.ts';
 
 enum Attribute {
     csvName = '_FILE',
@@ -42,6 +43,10 @@ class Data {
     // all elements are capitalised and the array is duplicate-free
     public columnList: string[] = ['_FILE'];
 
+    // Data class is blind about what each column represents. dataStats gives meaningful data about important columns's useful ranges and stats
+    // (Date, 'ACTUAL DATE' is also handled by Data, but processed in isolation for each csv)
+    public dataStats: DataStats = new DataStats(this);
+
     public readDatabase() {
         return this.sortedDatabase;
     }
@@ -71,6 +76,7 @@ class Data {
             this.sets,
             this.cellProcessors
         );
+        this.dataStats.refresh();
     }
 
     public removeCSV(CSVName: string) {
@@ -89,6 +95,7 @@ class Data {
             }
         }
         db.length = newI;
+        this.dataStats.refresh();
     }
 
     // filename: 0

--- a/devfiles/src/classes/data/DataStats.ts
+++ b/devfiles/src/classes/data/DataStats.ts
@@ -1,4 +1,5 @@
 import RangeMeta from '../queryMeta/RangeMeta';
+import SetMeta from '../queryMeta/SetMeta';
 import SpeciesMeta from '../queryMeta/SpeciesMeta';
 import { Attribute, Data } from './Data';
 import SetElement from './setutils/SetElement';
@@ -51,6 +52,10 @@ export default class DataStats {
     // You shouldn't need to call this more than once but no harm otherwise
     public getSpeciesMeta() {
         return new SpeciesMeta(this.species);
+    }
+
+    public getSetMeta() {
+        return new SetMeta(this.data.sets[0]);
     }
 
     // You shouldn't need to call this more than once but no harm otherwise

--- a/devfiles/src/classes/data/DataStats.ts
+++ b/devfiles/src/classes/data/DataStats.ts
@@ -1,0 +1,60 @@
+import RangeMeta from '../queryMeta/RangeMeta';
+import SpeciesMeta from '../queryMeta/SpeciesMeta';
+import { Attribute, Data } from './Data';
+import SetElement from './setutils/SetElement';
+
+// currently, recalculates for all data whenever updated
+export default class DataStats {
+    private data: Data;
+
+    private species: [species: SetElement, count: number][][] = []; // [[SetElement("Anglican skybird"), 100], [SetElement("Anglican skybird"), 150]]
+    private timeRange: [Date, Date, colI: number | undefined] = [
+        -Infinity as unknown as Date,
+        +Infinity as unknown as Date,
+        undefined
+    ];
+
+    public constructor(d: Data) {
+        this.data = d;
+        if (!d) throw 'Stats uninitialized'; // can be removed
+    }
+
+    public refresh() {
+        // date range ('ACTUAL DATE')
+        const dateCol = this.data.getIndexForColumn(Attribute.actualDate);
+        if (dateCol) {
+            let min = +Infinity as unknown as Date;
+            let max = -Infinity as unknown as Date;
+            const db = this.data.readDatabase(),
+                l = db.length;
+            for (let i = 0; i < l; i++) {
+                const d = db[i][dateCol];
+                if (!(d instanceof Date)) continue;
+                if ((db[i][dateCol] as unknown as Date) < min)
+                    min = db[i][dateCol] as unknown as Date;
+                if ((db[i][dateCol] as unknown as Date) > max)
+                    max = db[i][dateCol] as unknown as Date;
+            }
+            this.timeRange[0] = min;
+            this.timeRange[1] = max;
+        }
+        if (!dateCol || !this.timeRange[0] || !this.timeRange[1]) {
+            this.timeRange[2] = undefined;
+        } else {
+            this.timeRange[2] = dateCol;
+        }
+        // species count array
+
+        //const this.data.getIndexForColumn(Attribute.actualDate);
+    }
+
+    // You shouldn't need to call this more than once but no harm otherwise
+    public getSpeciesMeta() {
+        return new SpeciesMeta(this.species);
+    }
+
+    // You shouldn't need to call this more than once but no harm otherwise
+    public getTimeMeta() {
+        return new RangeMeta(this.timeRange);
+    }
+}

--- a/devfiles/src/classes/data/datautils/date.ts
+++ b/devfiles/src/classes/data/datautils/date.ts
@@ -1,0 +1,154 @@
+// High frequency was seen to use 30/01/2024, 01/30/2024
+// Bird data was seen to use 20240130
+
+enum DateType {
+    DDMMYYYY,
+    MMDDYYYY,
+    YYYYMMDD
+}
+
+enum DateSeparator {
+    NONE = '',
+    SLASH = '/',
+    DOT = '.',
+    HYPHEN = '-'
+}
+
+// Only call if there's date column in data
+// processes dataArray, returns data
+export function processDates(
+    dataArr,
+    startI,
+    columnI
+): [DateType | undefined, DateSeparator | undefined] {
+    // pick a random cell
+    if (dataArr.length == 0) return undefined;
+    const example: string = dataArr[Math.floor(startI + (dataArr.length - startI) / 2)][columnI];
+    let separators = '',
+        sep: DateSeparator,
+        type: DateType;
+    if (example.includes('-')) {
+        separators += '-';
+    }
+    if (example.includes('/')) {
+        separators += '/';
+    }
+    if (example.includes('.')) {
+        separators += '.';
+    }
+    if (separators.length > 1) {
+        return [undefined, undefined];
+    }
+    if (separators.length) {
+        sep = separators as DateSeparator;
+    } else {
+        sep = DateSeparator.NONE;
+    }
+
+    // DDMM or MMDD?
+    let scanNeeded = false;
+    let processBeforeScan; // e.g. 0124 or 01.24 -> ["01","24"]
+
+    if (sep == DateSeparator.NONE) {
+        // search for years.
+        const currentYear = new Date().getFullYear();
+        let BTOPipelineAvailable = 2021;
+        const years = new Array(currentYear - BTOPipelineAvailable + 1);
+        for (; BTOPipelineAvailable <= currentYear; BTOPipelineAvailable++) {
+            years[BTOPipelineAvailable - 2021] = [
+                BTOPipelineAvailable,
+                example.includes('' + BTOPipelineAvailable)
+            ];
+        }
+        const potentialYears = years.filter((a) => a[1]);
+        if (potentialYears.length > 2 || potentialYears.length == 0) return [undefined, undefined];
+        // we could look at all other dates in data
+        // DDMMYYY or MMDDYYYY
+        // the second case allows potentialYears.length == 2
+        if (potentialYears.length == 2) {
+            // assert MMDDYYYY
+            type = DateType.MMDDYYYY;
+        } else {
+            // assert year at beginning or at end
+            if (example.startsWith('' + years[0])) {
+                type = DateType.YYYYMMDD;
+            } else if (example.endsWith('' + years[0])) {
+                //SCAN and decide if DDMM or MMDD
+                scanNeeded = true;
+                processBeforeScan = (s) => [s.slice(0, 2), s.slice(2, 4)];
+            } else {
+                return [undefined, undefined];
+            }
+        }
+    } else {
+        // decide which order
+        const date = example.split(sep);
+        if (date.length != 3) {
+            return [undefined, undefined];
+        }
+        if (
+            date[0].length == 4 &&
+            (date[1].length == 1 || date[1].length == 2) &&
+            (date[2].length == 1 || date[2].length == 2)
+        ) {
+            type = DateType.YYYYMMDD;
+        } else if (
+            date[2].length == 4 &&
+            (date[1].length == 1 || date[1].length == 2) &&
+            (date[0].length == 1 || date[0].length == 2)
+        ) {
+            //SCAN and decide if DDMM or MMDD
+            scanNeeded = true;
+            processBeforeScan = (s) => [s.slice(0, 2), s.slice(3, 5)];
+        } else {
+            return [undefined, undefined];
+        }
+    }
+
+    if (scanNeeded) {
+        for (let i = 0; i < dataArr.length; i++) {
+            const y = processBeforeScan(dataArr[i][columnI]);
+            if (y[0] > '12' || y[1] > '12') {
+                if (y[0] > '12') {
+                    type = DateType.DDMMYYYY;
+                    break;
+                } else {
+                    type = DateType.MMDDYYYY;
+                    break;
+                }
+            }
+        }
+    }
+
+    let processor: (s) => Date;
+    if (sep == DateSeparator.NONE) {
+        switch (type) {
+            case DateType.DDMMYYYY:
+                processor = (s) => new Date(s.slice(4), s.slice(2, 4), s.slice(0, 2));
+                break;
+            case DateType.MMDDYYYY:
+                processor = (s) => new Date(s.slice(4), s.slice(0, 2), s.slice(2, 4));
+                break;
+            case DateType.YYYYMMDD:
+                processor = (s) => new Date(s.slice(0, 4), s.slice(4, 6), s.slice(6));
+                break;
+        }
+    } else {
+        switch (type) {
+            case DateType.DDMMYYYY:
+                processor = (s) => new Date(s.slice(6), s.slice(3, 5), s.slice(0, 2));
+                break;
+            case DateType.MMDDYYYY:
+                processor = (s) => new Date(s.slice(6), s.slice(0, 2), s.slice(3, 5));
+                break;
+            case DateType.YYYYMMDD:
+                processor = (s) => new Date(s.slice(0, 4), s.slice(5, 7), s.slice(8));
+                break;
+        }
+    }
+
+    const l = dataArr.length;
+    for (let i = 0; i < l; i++) {
+        dataArr[i][columnI] = processor(dataArr[i][columnI]);
+    }
+}

--- a/devfiles/src/classes/data/datautils/table_integrate.ts
+++ b/devfiles/src/classes/data/datautils/table_integrate.ts
@@ -1,7 +1,9 @@
 /* Handles merging multiple files together */
 //import FileIdentifierManager from "../setutils/FileIdentifierManager";
 
+import { Attribute } from '../Data';
 import ReferenceSet from '../setutils/ReferenceSet';
+import { processDates } from './date';
 
 function matchColumnNames(upperCaseColumnName) {
     switch (upperCaseColumnName) {
@@ -10,6 +12,8 @@ function matchColumnNames(upperCaseColumnName) {
             return 'PROBABILITY';
         case 'COMMON_NAME': // Underscore, because from bird pipeline CSV
             return 'ENGLISH NAME';
+        case 'DATE':
+            return 'ACTUAL DATE'; // map Date from bird pipeline to actual date
         default:
             return upperCaseColumnName;
     }
@@ -117,6 +121,7 @@ function integrateNewCSV(
     // Extend processors, process old data
     // NOTE: NOT IMPLEMENTED: it isn't useful to extend old data with NaN, unknown dates, and SetElement("") and ""
     // INCONSISTENCY: but we do process empty columns of the new rows (if the new data doesn't have some columns as the original)
+    // but this has good effect that we can replace processor with every new csv
 
     // Extend processors, process new data with both old and new processors
     // for this, extend set
@@ -126,6 +131,16 @@ function integrateNewCSV(
     const newProcessors = newColumns.map((n, i) => getProcessorForColumn(n, newSets[i]));
     oldSets.push(...newSets);
     oldProcessors.push(...newProcessors);
+
+    // handle time: get index of actual ...
+    // make processor, replace previous with it
+
+    const dateCol = titleToColumnIndex.get(Attribute.actualDate);
+    if (dateCol) {
+        // TODO: perhaps move processing here?
+        processDates(oldDatabase, oldDBLen, dateCol);
+    }
+
     for (let i = oldDBLen; i < finalDBLen; i++) {
         const r = oldDatabase[i];
         // Skip file identifier
@@ -166,11 +181,9 @@ function getProcessorForColumn(columnName, set: ReferenceSet) /*: (cell: string)
             return (a) => set.addRawOrGet(a);
 
         case 'ACTUAL DATE':
-            // Infer american or british
             return (x) => x;
 
         case 'SURVEY DATE':
-            // Infer american or british
             return (x) => x;
 
         case 'TIME':
@@ -237,7 +250,7 @@ function columnNeedsSet(columnName) {
             return true;
 
         default:
-            throw 'unknown column ' + columnName;
+            return false; //'unknown column ' + columnName;
     }
 }
 

--- a/devfiles/src/classes/filters/RangeFilter.ts
+++ b/devfiles/src/classes/filters/RangeFilter.ts
@@ -1,5 +1,4 @@
 import { Filter, PredicateType } from './Filter.ts';
-import ReferenceSet from '../data/setutils/ReferenceSet.ts';
 
 export default class RangeFilter implements Filter {
     private l: number;

--- a/devfiles/src/classes/options/Geographic.tsx
+++ b/devfiles/src/classes/options/Geographic.tsx
@@ -1,4 +1,4 @@
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class Geographic extends InputOption {

--- a/devfiles/src/classes/options/InputOption.tsx
+++ b/devfiles/src/classes/options/InputOption.tsx
@@ -1,5 +1,5 @@
 import Panel from '../Panel';
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 
 export default abstract class InputOption {
     public readonly name: string;

--- a/devfiles/src/classes/options/MutuallyExclusiveSelector.tsx
+++ b/devfiles/src/classes/options/MutuallyExclusiveSelector.tsx
@@ -1,4 +1,4 @@
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class MutuallyExclusiveSelector extends InputOption {

--- a/devfiles/src/classes/options/NumericInput.tsx
+++ b/devfiles/src/classes/options/NumericInput.tsx
@@ -1,4 +1,4 @@
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class NumericInput extends InputOption {

--- a/devfiles/src/classes/options/PanelNameInput.tsx
+++ b/devfiles/src/classes/options/PanelNameInput.tsx
@@ -1,5 +1,5 @@
 import Panel from '../Panel';
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 /**

--- a/devfiles/src/classes/options/Selector.tsx
+++ b/devfiles/src/classes/options/Selector.tsx
@@ -1,6 +1,6 @@
 import Panel from '../Panel';
 import DataFilterer from '../data/DataFilterer';
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class Selector extends InputOption {

--- a/devfiles/src/classes/options/TextInput.tsx
+++ b/devfiles/src/classes/options/TextInput.tsx
@@ -1,4 +1,4 @@
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class TextInput extends InputOption {

--- a/devfiles/src/classes/options/TimeRange.tsx
+++ b/devfiles/src/classes/options/TimeRange.tsx
@@ -1,4 +1,4 @@
-import Query from '../query/Query';
+import { Query } from '../query/Query';
 import InputOption from './InputOption';
 
 export default class TimeRange extends InputOption {

--- a/devfiles/src/classes/query/Query.ts
+++ b/devfiles/src/classes/query/Query.ts
@@ -1,7 +1,23 @@
-import Row from '../data/Row';
+import SetElement from '../data/setutils/SetElement';
 
-export default abstract class Query {
-    abstract getFilter(): (row: Row) => boolean;
-
-    abstract compose(query: Query): Query;
+// Query: [columnIndex, QueryTypes.xxx, ...]
+export enum QueryType {
+    Range = 0,
+    SetElem = 1,
+    Set = 2
 }
+
+export type RangeQuery = [colI: number, QueryType.Range, low: number, high: number];
+export type SetElemQuery = [
+    colI: number,
+    QueryType.SetElem,
+    e: SetElement,
+    oneOrTrueForAccept0orFalseForReject: number | boolean
+];
+export type SetQuery = [
+    colI: number,
+    QueryType.Set,
+    twoForInvertOneOrTrueForAccept0orFalseForReject: number | boolean
+];
+
+export type Query = RangeQuery | SetElemQuery | SetQuery;

--- a/devfiles/src/classes/query/RangeQuery.ts
+++ b/devfiles/src/classes/query/RangeQuery.ts
@@ -1,0 +1,14 @@
+import { QueryType } from './Query';
+
+export default class RangeQuery {
+    colI: any;
+    public constructor(columnIndex) {
+        this.colI = columnIndex;
+    }
+    // Note: if the user didn't specifically choose a range, use -Infinity and +Infinite and not the max and min in dataset
+    // this will allow keeping rows that perhaps don't have a date
+    // for this, check if the slider is touching the border of line or the textinput has value same as its limit, then pass infinity if so
+    public query(low: number | Date, up: number | Date) {
+        return [this.colI, QueryType.Range, low, up];
+    }
+}

--- a/devfiles/src/classes/query/SetQueryElement.ts
+++ b/devfiles/src/classes/query/SetQueryElement.ts
@@ -1,0 +1,13 @@
+import SetElement from '../data/setutils/SetElement';
+import { QueryType } from './Query';
+
+export default class SetQueryElement {
+    colI: any;
+    e: SetElement;
+    public constructor(columnIndex) {
+        this.colI = columnIndex;
+    }
+    public query(enable: boolean) {
+        return [this.colI, QueryType.SetElem, enable];
+    }
+}

--- a/devfiles/src/classes/query/SetQueryGeneral.ts
+++ b/devfiles/src/classes/query/SetQueryGeneral.ts
@@ -1,0 +1,12 @@
+import { QueryType } from './Query';
+
+export default class SetQuery {
+    colI: any;
+    public constructor(columnIndex) {
+        this.colI = columnIndex;
+    }
+    // 0 or false for disable all, 1 or true for enable all, 2 for invert selection
+    public query(mode: boolean | number) {
+        return [this.colI, QueryType.Set, mode];
+    }
+}

--- a/devfiles/src/classes/queryMeta/RangeMeta.ts
+++ b/devfiles/src/classes/queryMeta/RangeMeta.ts
@@ -1,0 +1,7 @@
+export default class RangeMeta {
+    // -Infinity, +Infinity, undefined when no data loaded or data doesn't have time
+    value: [low: number | Date, up: number | Date, colI: number | undefined];
+    public constructor(arr) {
+        this.value = arr;
+    }
+}

--- a/devfiles/src/classes/queryMeta/RangeMeta.ts
+++ b/devfiles/src/classes/queryMeta/RangeMeta.ts
@@ -1,6 +1,6 @@
 export default class RangeMeta {
     // -Infinity, +Infinity, undefined when no data loaded or data doesn't have time
-    value: [low: number | Date, up: number | Date, colI: number | undefined];
+    public value: [low: number | Date, up: number | Date, colI: number | undefined];
     public constructor(arr) {
         this.value = arr;
     }

--- a/devfiles/src/classes/queryMeta/SetMeta.ts
+++ b/devfiles/src/classes/queryMeta/SetMeta.ts
@@ -1,0 +1,10 @@
+import ReferenceSet from '../data/setutils/ReferenceSet';
+
+export default class SetMeta {
+    // Note: don't modify this
+    // Reread from value when got a signal that CSV added or CSV removed
+    public value: ReferenceSet;
+    public constructor(s) {
+        this.value = s;
+    }
+}

--- a/devfiles/src/classes/queryMeta/SpeciesMeta.ts
+++ b/devfiles/src/classes/queryMeta/SpeciesMeta.ts
@@ -1,0 +1,11 @@
+import SetElement from '../data/setutils/SetElement';
+
+export default class SpeciesMeta {
+    // Note: don't modify this, but use toSorted() (for example, alphabetical toSorted(x => x[0].value) or population toSorted(x => x[1])), etc. to make a new array
+    // Please don't assume any order on this
+    // Reread from value when got a signal that CSV added or CSV removed
+    public value: [species: SetElement, count: number][][]; // [[SetElement("Anglican skybird"), 100], [SetElement("Anglican skybird"), 150]]
+    public constructor(s) {
+        this.value = s;
+    }
+}


### PR DESCRIPTION
@Hex27 This is relevant for you: getTimeMeta() from dataStats. Two options: 1) call this once, then make pageManager.addCSV or removeCSV re-retrieve the values inside the array and display these to the user 2) call this as many times as you want; so pageManager.addCSV and removeCSV makes it call getTimeMeta and replace the previous object. Both are the same.

When the user does something, you pass the query to `processQuery` in panel's dataFilter.

Currently it should be possible to do this for time range and set of files for each panel

I need to discuss queries for species