### PR TITLE
Represent dates as strings in our database

### DIFF
--- a/devfiles/src/classes/data/datautils/date.ts
+++ b/devfiles/src/classes/data/datautils/date.ts
@@ -14,6 +14,12 @@ enum DateSeparator {
     HYPHEN = '-'
 }
 
+// in our database, for "actual date", use 2024-01-30 etc.
+// assumes: these are int, positive, and in correct ranges
+function stringDate(y: string, m: string, d: string) {
+    return y + '-' + (m.length == 2 ? m : '0' + m) + '-' + (d.length == 2 ? d : '0' + d);
+}
+
 // Only call if there's date column in data
 // processes dataArray, returns data
 export function processDates(
@@ -120,29 +126,29 @@ export function processDates(
         }
     }
 
-    let processor: (s) => Date;
+    let processor: (s) => string;
     if (sep == DateSeparator.NONE) {
         switch (type) {
             case DateType.DDMMYYYY:
-                processor = (s) => new Date(s.slice(4), s.slice(2, 4), s.slice(0, 2));
+                processor = (s) => stringDate(s.slice(4), s.slice(2, 4), s.slice(0, 2));
                 break;
             case DateType.MMDDYYYY:
-                processor = (s) => new Date(s.slice(4), s.slice(0, 2), s.slice(2, 4));
+                processor = (s) => stringDate(s.slice(4), s.slice(0, 2), s.slice(2, 4));
                 break;
             case DateType.YYYYMMDD:
-                processor = (s) => new Date(s.slice(0, 4), s.slice(4, 6), s.slice(6));
+                processor = (s) => stringDate(s.slice(0, 4), s.slice(4, 6), s.slice(6));
                 break;
         }
     } else {
         switch (type) {
             case DateType.DDMMYYYY:
-                processor = (s) => new Date(s.slice(6), s.slice(3, 5), s.slice(0, 2));
+                processor = (s) => stringDate(s.slice(6), s.slice(3, 5), s.slice(0, 2));
                 break;
             case DateType.MMDDYYYY:
-                processor = (s) => new Date(s.slice(6), s.slice(0, 2), s.slice(3, 5));
+                processor = (s) => stringDate(s.slice(6), s.slice(0, 2), s.slice(3, 5));
                 break;
             case DateType.YYYYMMDD:
-                processor = (s) => new Date(s.slice(0, 4), s.slice(5, 7), s.slice(8));
+                processor = (s) => stringDate(s.slice(0, 4), s.slice(5, 7), s.slice(8));
                 break;
         }
     }

--- a/devfiles/src/classes/query/RangeQuery.ts
+++ b/devfiles/src/classes/query/RangeQuery.ts
@@ -8,7 +8,7 @@ export default class RangeQuery {
     // Note: if the user didn't specifically choose a range, use -Infinity and +Infinite and not the max and min in dataset
     // this will allow keeping rows that perhaps don't have a date
     // for this, check if the slider is touching the border of line or the textinput has value same as its limit, then pass infinity if so
-    public query(low: number | Date, up: number | Date) {
+    public query(low: number, up: number) {
         return [this.colI, QueryType.Range, low, up];
     }
 }

--- a/devfiles/src/classes/widgets/TableWidget.tsx
+++ b/devfiles/src/classes/widgets/TableWidget.tsx
@@ -54,16 +54,8 @@ export default class TableWidget extends Widget {
         const data = this.panel.dataFilterer.getData()[0];
         const dataLength = this.panel.dataFilterer.getData()[1];
         const indices = this.columns.map((c) => c[1]);
-        this.tableEntries = TableWidget.processAsArray(data, dataLength, indices);
         //Collect and group the relevant rows.
-        /*const rowMap = TableWidget.groupByFrequency(
-            this.panel.dataFilterer.getData()[0],
-            this.panel.dataFilterer.getData()[1],
-            selectedIndices
-        );
-
-        //Sort the rows by count. Potential for optimisation here if needed, this is insertion sort
-        this.tableEntries = TableWidget.sortByFrequency(rowMap);*/
+        this.tableEntries = TableWidget.processAsArray(data, dataLength, indices);
 
         return new Sidebar(this.options);
     }
@@ -105,6 +97,7 @@ export default class TableWidget extends Widget {
         arr.sort((a, b) => (a == b ? 0 : a < b ? -1 : 1));
 
         // Collect same strings, they're consecutive
+        //Potential optimisation to build the DOM straight in here
         const newArr = [];
         let old: string = arr[0],
             oldCount: number = 1;
@@ -122,51 +115,6 @@ export default class TableWidget extends Widget {
         newArr.sort((a, b) => b[1] - a[1]);
 
         return newArr;
-    }
-
-    //These are static to facilitate testing.
-    protected static groupByFrequency(
-        dataRows: any,
-        dataLength: number,
-        selectedIndices: number[]
-    ) {
-        const rowMap: Map<string, number> = new Map();
-        for (let i = 0; i < dataLength; i++) {
-            const row = dataRows[i];
-            const keyList = [];
-            selectedIndices.forEach((j) => {
-                if (row[j] instanceof SetElement) keyList.push(row[j].value);
-                else keyList.push(row[j]);
-            });
-            if (keyList.includes('')) continue;
-            const key = keyList.join('\0');
-
-            const count = rowMap.get(key);
-            rowMap.set(key, count ? count + 1 : 1);
-        }
-        return rowMap;
-    }
-
-    //These are static to facilitate testing.
-    protected static sortByFrequency(rowMap: Map<string, number>) {
-        const entries: [string, number][] = [];
-        const iterator = rowMap.entries();
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            const entry = iterator.next();
-            if (entry.done === true) break;
-            const freq: number = entry.value[1];
-            let inserted = false;
-            for (let i = 0; i < entries.length; i++) {
-                if (entries[i][1] < freq) {
-                    entries.splice(i, 0, entry.value);
-                    inserted = true;
-                    break;
-                }
-            }
-            if (!inserted) entries.push(entry.value);
-        }
-        return entries;
     }
 
     public render(): JSX.Element {


### PR DESCRIPTION
- Don't use new Date(...). We can represent dates as strings in the format YYYY-MM-DD which can be sorted the same way as strings.
- For the Table widget, searching on google "finding duplicates in array" suggests the algorithm that we write each row as a string, then sort them, then take consecutive elements as frequency. TODOs for next pull requests: pagination and search bar for table, bring back order of columns to sidebar order