### PR TITLE
Small updates

### DIFF
--- a/devfiles/src/App.tsx
+++ b/devfiles/src/App.tsx
@@ -40,12 +40,13 @@ function App() {
                 }
                 window['pageManager'] = pageManager;
                 try {
-                    pageManager.addCSV(file.value.name, file.value.data);
+                    pageManager.addCSV(file.value.name, file.value.data, true);
                 } catch (e) {
                     rejected.push(file.value.name + ': ' + e);
                     return;
                 }
             });
+            pageManager.finaliseAddingCSVs();
             if (borderRef.current) borderRef.current.style.opacity = 0;
             if (spinnerRef.current) spinnerRef.current.style.opacity = 0;
             setIsOverlaySuccess(rejected.length == 0);

--- a/devfiles/src/App.tsx
+++ b/devfiles/src/App.tsx
@@ -6,6 +6,13 @@ import MainPage from './ui/MainPage.tsx';
 import PageManager from './classes/PageManager.ts';
 import { Fade, Spinner } from 'react-bootstrap';
 
+// https://caniuse.com/?search=es2020 "Feature support list"
+// We target ES2020, 95% of browsers
+if (!Promise.allSettled) {
+    document.body.innerHTML =
+        "BTO Pipeline CSV visualization tool has detected that you're using an outdated browser. Unfortunately this browser is not supported. Please upgrade to a newer browser. Thank you.";
+}
+
 function App() {
     const [overlayVisible, setOverlayVisible] = useState(false);
     const [overlayMessage, setOverlayMessage] = useState('');

--- a/devfiles/src/classes/PageManager.ts
+++ b/devfiles/src/classes/PageManager.ts
@@ -29,8 +29,13 @@ export default class PageManager {
         return this.data;
     }
 
-    public addCSV(CSVName: string, CSVFile: Uint8Array) {
-        this.data.addCSV(CSVName, CSVFile);
+    public addCSV(CSVName: string, CSVFile: Uint8Array, finaliseLater: boolean) {
+        this.data.addCSV(CSVName, CSVFile, finaliseLater);
+        if (!finaliseLater) this.panels.forEach((p) => p.refresh());
+    }
+
+    public finaliseAddingCSVs() {
+        this.data.finaliseAdding();
         this.panels.forEach((p) => p.refresh());
     }
 

--- a/devfiles/src/classes/data/Data.ts
+++ b/devfiles/src/classes/data/Data.ts
@@ -57,7 +57,7 @@ class Data {
 
     // Throws an error message (such as: malformed CSV) to be appended to filename to become "abc.csv: malformed CSV"
     /* eslint no-var: off */
-    public addCSV(CSVName: string, CSVFile: Uint8Array) {
+    public addCSV(CSVName: string, CSVFile: Uint8Array, finaliseLater: boolean) {
         CSVName = normaliseIdentifier(CSVName, this.sets[0]);
         const CSVIdentifier = this.sets[0].addRawOrGet(CSVName);
         try {
@@ -76,6 +76,10 @@ class Data {
             this.sets,
             this.cellProcessors
         );
+        if (!finaliseLater) this.dataStats.refresh();
+    }
+
+    public finaliseAdding() {
         this.dataStats.refresh();
     }
 
@@ -97,6 +101,9 @@ class Data {
         db.length = newI;
         this.dataStats.refresh();
     }
+
+    // On delete, rescan the remaining list, and take out from sets
+    public remakeSets() {}
 
     // filename: 0
     public getIndexForColumn(a: Attribute | string): number {

--- a/devfiles/src/classes/data/DataStats.ts
+++ b/devfiles/src/classes/data/DataStats.ts
@@ -9,7 +9,7 @@ export default class DataStats {
     private data: Data;
 
     private species: [species: SetElement, count: number][][] = []; // [[SetElement("Anglican skybird"), 100], [SetElement("Anglican skybird"), 150]]
-    private timeRange: undefined | [string, string, colI: number] = undefined;
+    private timeRange: [] | [low: string, up: string, colI: number] = [];
 
     public constructor(d: Data) {
         this.data = d;
@@ -30,15 +30,13 @@ export default class DataStats {
                 if (d < min) min = d;
                 if (d > max) max = d;
             }
-            this.timeRange[0] = min;
-            this.timeRange[1] = max;
         }
         if (min != 'z') {
             this.timeRange[0] = min;
             this.timeRange[1] = max;
             this.timeRange[2] = dateCol;
         } else {
-            this.timeRange = undefined;
+            this.timeRange.length = 0;
         }
         // species count array
 

--- a/devfiles/src/classes/data/DataStats.ts
+++ b/devfiles/src/classes/data/DataStats.ts
@@ -9,11 +9,7 @@ export default class DataStats {
     private data: Data;
 
     private species: [species: SetElement, count: number][][] = []; // [[SetElement("Anglican skybird"), 100], [SetElement("Anglican skybird"), 150]]
-    private timeRange: [Date, Date, colI: number | undefined] = [
-        -Infinity as unknown as Date,
-        +Infinity as unknown as Date,
-        undefined
-    ];
+    private timeRange: undefined | [string, string, colI: number] = undefined;
 
     public constructor(d: Data) {
         this.data = d;
@@ -23,29 +19,26 @@ export default class DataStats {
     public refresh() {
         // date range ('ACTUAL DATE')
         const dateCol = this.data.getIndexForColumn(Attribute.actualDate);
+        let min = 'z';
+        let max = '0';
         if (dateCol) {
-            let min = +Infinity as unknown as Date;
-            let max = -Infinity as unknown as Date;
             const db = this.data.readDatabase(),
                 l = db.length;
             for (let i = 0; i < l; i++) {
-                const d = db[i][dateCol];
-                if (!(d instanceof Date)) continue;
-                if ((db[i][dateCol] as unknown as Date) < min)
-                    min = db[i][dateCol] as unknown as Date;
-                if ((db[i][dateCol] as unknown as Date) > max)
-                    max = db[i][dateCol] as unknown as Date;
+                const d = db[i][dateCol] as string;
+                if (!d.startsWith('20')) continue;
+                if (d < min) min = d;
+                if (d > max) max = d;
             }
             this.timeRange[0] = min;
             this.timeRange[1] = max;
-        } else {
-            this.timeRange[0] = -Infinity as unknown as Date;
-            this.timeRange[1] = +Infinity as unknown as Date;
         }
-        if (!dateCol || this.timeRange[0] == (-Infinity as unknown as Date)) {
-            this.timeRange[2] = undefined;
-        } else {
+        if (min != 'z') {
+            this.timeRange[0] = min;
+            this.timeRange[1] = max;
             this.timeRange[2] = dateCol;
+        } else {
+            this.timeRange = undefined;
         }
         // species count array
 

--- a/devfiles/src/classes/queryMeta/RangeMeta.ts
+++ b/devfiles/src/classes/queryMeta/RangeMeta.ts
@@ -1,6 +1,7 @@
 export default class RangeMeta {
-    // -Infinity, +Infinity, undefined when no data loaded or data doesn't have time
-    public value: [low: number | string, up: number | string, colI: number | undefined];
+    // if length 0, then invalid, ie, no such column
+    // if length 3, valid
+    public value: [] | [low: string, up: string, colI: number];
     public constructor(arr) {
         this.value = arr;
     }

--- a/devfiles/src/classes/queryMeta/RangeMeta.ts
+++ b/devfiles/src/classes/queryMeta/RangeMeta.ts
@@ -1,6 +1,6 @@
 export default class RangeMeta {
     // -Infinity, +Infinity, undefined when no data loaded or data doesn't have time
-    public value: [low: number | Date, up: number | Date, colI: number | undefined];
+    public value: [low: number | string, up: number | string, colI: number | undefined];
     public constructor(arr) {
         this.value = arr;
     }

--- a/devfiles/src/classes/widgets/TableWidget.tsx
+++ b/devfiles/src/classes/widgets/TableWidget.tsx
@@ -50,6 +50,7 @@ export default class TableWidget extends Widget {
                 /* Data doesn't have that - skip */
             }
         });
+        this.columns.sort((a, b) => a[1] - b[1]);
 
         const data = this.panel.dataFilterer.getData()[0];
         const dataLength = this.panel.dataFilterer.getData()[1];
@@ -94,7 +95,7 @@ export default class TableWidget extends Widget {
         if (arrLength == 0) return [];
 
         // Order the strings
-        arr.sort((a, b) => (a == b ? 0 : a < b ? -1 : 1));
+        arr.sort();
 
         // Collect same strings, they're consecutive
         //Potential optimisation to build the DOM straight in here


### PR DESCRIPTION
- Warn on outdated browser
- Add option to defer calculating statistics after an array is updated. Stats are calculated from beginning to end so they should be calculated only after a whole array is uploaded
- Table widget: use default sorting function. also sort columns to match sidebar
- Time range: if [] then no such column, otherwise an array. As before, calling `getTimeMeta` once is enough; the resultant object will contain the array that will be remotely kept updated.