### PR TITLE
Speedups for code that run on every filter update/rerender

### DIFF
--- a/devfiles/src/classes/data/DataStats.ts
+++ b/devfiles/src/classes/data/DataStats.ts
@@ -25,6 +25,7 @@ export default class DataStats {
     > = new Map();
 
     private positionMeta: PositionMeta;
+    private speciesMeta: SpeciesMeta;
 
     public constructor(d: Data) {
         this.data = d;
@@ -99,11 +100,13 @@ export default class DataStats {
             }
             rowIndex++;
         }
+
+        this.speciesMeta = new SpeciesMeta(this.species);
     }
 
     // You shouldn't need to call this more than once but no harm otherwise
     public getSpeciesMeta() {
-        return new SpeciesMeta(this.species);
+        return this.speciesMeta;
     }
 
     public getFilesMeta() {

--- a/devfiles/src/classes/options/NumericInput.tsx
+++ b/devfiles/src/classes/options/NumericInput.tsx
@@ -59,7 +59,11 @@ export default class NumericInput extends InputOption {
                                 max={this.max}
                                 step={this.step}
                                 onChange={(event) => {
-                                    this.callback(event.target.valueAsNumber);
+                                    this.value = event.target.valueAsNumber;
+                                    this.refreshComponent();
+                                }}
+                                onMouseUp={(event) => {
+                                    this.callback();
                                 }}
                             />
                             <p>Selected Value: {this.value}</p>
@@ -69,10 +73,10 @@ export default class NumericInput extends InputOption {
             </Accordion>
         );
     }
-    public callback(newValue: number): void {
-        this.value = newValue;
+    public callback(): void {
+        // this.value = newValue;
+        // this.panel.refreshComponent();
         this.panel.recalculateFilters(this);
-        this.panel.refreshComponent();
         this.panel.refreshWidgets();
         //Refresh this inputoption
         this.refreshComponent();

--- a/devfiles/src/classes/options/NumericInput.tsx
+++ b/devfiles/src/classes/options/NumericInput.tsx
@@ -81,7 +81,7 @@ export default class NumericInput extends InputOption {
     public query(): Query {
         return new RangeQuery(this.panel.dataFilterer.getColumnIndex(Attribute.probability)).query(
             this.value,
-            this.max
+            Infinity
         );
     }
 }

--- a/devfiles/src/classes/queryMeta/SpeciesMeta.ts
+++ b/devfiles/src/classes/queryMeta/SpeciesMeta.ts
@@ -1,4 +1,5 @@
 import { EndangermentStatus } from '../../utils/speciesVulnerability';
+import ReferenceSet from '../data/setutils/ReferenceSet';
 import SetElement from '../data/setutils/SetElement';
 
 export default class SpeciesMeta {
@@ -16,6 +17,8 @@ export default class SpeciesMeta {
     //A map of group SetElements to a list of latinNames
     public readonly groupByGroup: Map<SetElement, SetElement[]>;
 
+    private readonly latinNamesList: SetElement[];
+
     public constructor(
         species: Map<
             SetElement,
@@ -29,7 +32,8 @@ export default class SpeciesMeta {
     ) {
         this.species = species;
         this.groupByGroup = new Map();
-        [...this.species.keys()].forEach((latinName) => {
+        this.latinNamesList = [...this.species.keys()];
+        this.latinNamesList.forEach((latinName) => {
             const group = this.speciesGroup(latinName);
             if (!this.groupByGroup.has(group)) this.groupByGroup.set(group, [latinName]);
             else this.groupByGroup.get(group).push(latinName);
@@ -53,7 +57,8 @@ export default class SpeciesMeta {
         return this.species.get(latinName)[3];
     }
 
+    // Don't modify the resultant array
     public speciesList(): SetElement[] {
-        return [...this.species.keys()];
+        return this.latinNamesList;
     }
 }

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -50,7 +50,6 @@ abstract class Grouping {
             const map = aggregated.get(y);
             if (map === undefined) {
                 aggregated.set(y, new Map<SetElement, number>([[x, 1]]));
-                continue;
             } else {
                 const mapVal = map.get(x);
                 if (mapVal !== undefined) {

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -32,12 +32,14 @@ abstract class Grouping {
     // Select pairs of x-y values that will be aggregated and plotted.
     public generatePairs(): [SetElement, SetElement][] {
         const [data, length] = this.filter.getData();
-        const dataSubset = data.slice(0, length);
-        return dataSubset.map((row) => {
+        const out = new Array(length);
+        for (let i = 0; i < length; i++) {
+            const row = data[i];
             const x = this.selectX(row);
             this.xValues.add(x);
-            return [x, this.selectY(row)];
-        });
+            out[i] = [x, this.selectY(row)];
+        }
+        return out;
     }
     // Aggregate the pairs of x-y values.
     public aggregatePairs() {

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -51,8 +51,9 @@ abstract class Grouping {
             if (map === undefined) {
                 aggregated.set(y, (map = new Map<SetElement, number>()));
             }
-            if (map.has(x)) {
-                map.set(x, map.get(x).valueOf() + 1);
+            const mapVal = map.get(x);
+            if (mapVal !== undefined) {
+                map.set(x, mapVal + 1);
             } else {
                 map.set(x, 1);
             }

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -47,9 +47,10 @@ abstract class Grouping {
         // use y as the first key and x as the second
         const aggregated = new Map<SetElement, Map<SetElement, number>>();
         for (const [x, y] of pairs) {
-            let map = aggregated.get(y);
+            const map = aggregated.get(y);
             if (map === undefined) {
-                aggregated.set(y, (map = new Map<SetElement, number>()));
+                aggregated.set(y, new Map<SetElement, number>([[x, 1]]));
+                continue;
             }
             const mapVal = map.get(x);
             if (mapVal !== undefined) {

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -79,7 +79,8 @@ abstract class Grouping {
         const plottingData = this.aggregatePairs();
         const xIndexMap = this.xIndexMap();
         return Array.from(plottingData.entries()).map(([group, xValueMap]) => {
-            const x = Array.from(Array(xIndexMap.size).keys());
+            const x = new Array(xIndexMap.size);
+            for (let i = 0; i < x.length; i++) x[i] = i;
             const y = new Array(xIndexMap.size).fill(0);
             for (const [xValue, yValue] of xValueMap.entries()) {
                 y[xIndexMap.get(xValue)] = yValue;

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -47,13 +47,14 @@ abstract class Grouping {
         // use y as the first key and x as the second
         const aggregated = new Map<SetElement, Map<SetElement, number>>();
         for (const [x, y] of pairs) {
-            if (!aggregated.has(y)) {
-                aggregated.set(y, new Map<SetElement, number>());
+            let map = aggregated.get(y);
+            if (map === undefined) {
+                aggregated.set(y, (map = new Map<SetElement, number>()));
             }
-            if (aggregated.get(y).has(x)) {
-                aggregated.get(y).set(x, aggregated.get(y).get(x).valueOf() + 1);
+            if (map.has(x)) {
+                map.set(x, map.get(x).valueOf() + 1);
             } else {
-                aggregated.get(y).set(x, 1);
+                map.set(x, 1);
             }
         }
         return aggregated;

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -64,8 +64,9 @@ abstract class Grouping {
     // Convert x values to integers to display on chart.
     // Must be called after all pairs have been generated.
     public xIndexMap() {
+        // If the array is very long it's faster to map to string then sort then map back
         const sortedXValues = Array.from(this.xValues).sort((a, b) =>
-            a.value.localeCompare(b.value)
+            a.value < b.value ? -1 : a.value == b.value ? 0 : 1
         );
         const xValueMap = new Map<SetElement, number>();
         for (let i = 0; i < sortedXValues.length; i++) {

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -68,9 +68,7 @@ abstract class Grouping {
     // Must be called after all pairs have been generated.
     public xIndexMap() {
         // If the array is very long it's faster to map to string then sort then map back
-        const sortedXValues = this.xValuesArray.sort((a, b) =>
-            a.value < b.value ? -1 : a.value == b.value ? 0 : 1
-        );
+        const sortedXValues = this.xValuesArray.sort((a, b) => a.value.localeCompare(b.value));
         const xValueMap = new Map<SetElement, number>();
         for (let i = 0; i < sortedXValues.length; i++) {
             xValueMap.set(sortedXValues[i], i);

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -51,12 +51,13 @@ abstract class Grouping {
             if (map === undefined) {
                 aggregated.set(y, new Map<SetElement, number>([[x, 1]]));
                 continue;
-            }
-            const mapVal = map.get(x);
-            if (mapVal !== undefined) {
-                map.set(x, mapVal + 1);
             } else {
-                map.set(x, 1);
+                const mapVal = map.get(x);
+                if (mapVal !== undefined) {
+                    map.set(x, mapVal + 1);
+                } else {
+                    map.set(x, 1);
+                }
             }
         }
         return aggregated;


### PR DESCRIPTION
This pull request doesn't change code that happen on file upload/delete, since these happen rarely and it's not a problem if these happen slowly

- Reuse the "SpeciesMeta" object, don't recreate it every time
- Reuse the latin names array returned by SpeciesMeta


Grouping code:
- Instead of turning x values set to array every time, turn it to an array when the set is calculated, then reuse it.
- Handle "undefined case" of two maps faster: In Map<A,Map<B,C>>, if A wasn't found, then we know B won't be found either so make it new
- Avoid allocating twice with Array.from(Array(xIndexMap.size).keys());

Probability slider:
- Probability slider should use infinity as the upper bound, to halve the number of 
comparisons needed for it since we always assume that the probability is less than 1
- It should refilter onmouseup only