### PR TITLE
Table string pruning

### DIFF
--- a/devfiles/src/classes/widgets/TableWidget.test.ts
+++ b/devfiles/src/classes/widgets/TableWidget.test.ts
@@ -1,5 +1,63 @@
+import { loadData } from '../../tests/utils.test';
+import { Attribute, Data } from '../data/Data';
+import DataFilterer from '../data/DataFilterer';
+import { testDataFilename2 as filename } from '../../tests/utils.test';
+import TableWidget from './TableWidget';
+import SetElement from '../data/setutils/SetElement';
+
 describe('TableWidget.tsx', () => {
-    it('processAsArray can group rows as expected', () => {
-        expect(true).toBe(true);
+    let data: Data, filterer: DataFilterer;
+    beforeEach(async () => {
+        data = await loadData(filename);
+        filterer = new DataFilterer(data);
+    });
+    describe('processAsArray can group rows as expected', () => {
+        it('Group by Probability', () => {
+            const results = TableWidget.processAsArray(
+                filterer.getData()[0],
+                filterer.getData()[1],
+                [data.getIndexForColumn(Attribute.probability)],
+                false
+            );
+            expect(results[0][1]).toBe(1);
+            expect(results[1][1]).toBe(1);
+            expect(results[0][0]).not.toBe(results[1][0]);
+        });
+        it('Group by Species Group', () => {
+            const results = TableWidget.processAsArray(
+                filterer.getData()[0],
+                filterer.getData()[1],
+                [data.getIndexForColumn(Attribute.speciesGroup)],
+                false
+            );
+            expect(results.length).toBe(1); //there is only 1 species group here
+        });
+        it('Group by Scientific Name', () => {
+            const results = TableWidget.processAsArray(
+                filterer.getData()[0],
+                filterer.getData()[1],
+                [data.getIndexForColumn(Attribute.speciesLatinName)],
+                false
+            );
+            expect(
+                (
+                    filterer.getData()[0][results[0][0]][
+                        data.getIndexForColumn(Attribute.speciesLatinName)
+                    ] as SetElement
+                ).value
+            ).toBe('Cygnus olor');
+        });
+        it('Culling empty rows works', () => {
+            const results = TableWidget.processAsArray(
+                filterer.getData()[0],
+                filterer.getData()[1],
+                [
+                    data.getIndexForColumn(Attribute.callType),
+                    data.getIndexForColumn(Attribute.speciesLatinName)
+                ],
+                true
+            );
+            expect(results.length).toBe(0);
+        });
     });
 });

--- a/devfiles/src/classes/widgets/TableWidget.test.ts
+++ b/devfiles/src/classes/widgets/TableWidget.test.ts
@@ -1,0 +1,5 @@
+describe('TableWidget.tsx', () => {
+    it('processAsArray can group rows as expected', () => {
+        expect(true).toBe(true);
+    });
+});

--- a/devfiles/src/classes/widgets/TableWidget.tsx
+++ b/devfiles/src/classes/widgets/TableWidget.tsx
@@ -4,10 +4,11 @@ import ExportFileType from './ExportFileType.js';
 import Selector from '../options/Selector.js';
 import WidgetConfig from './WidgetConfig.js';
 import Panel from '../Panel.js';
-import { Attribute, Data } from '../data/Data.js';
+import { Attribute } from '../data/Data.js';
 import SetElement from '../data/setutils/SetElement.js';
 import { v4 as uuidv4 } from 'uuid';
 import MutuallyExclusiveSelector from '../options/MutuallyExclusiveSelector.js';
+import { hasEmpty, rowComparator, unpack } from '../../utils/DataUtils.js';
 
 /**
  * This will take in a set of input columns, then
@@ -16,10 +17,9 @@ import MutuallyExclusiveSelector from '../options/MutuallyExclusiveSelector.js';
  * Sort by top frequency
  */
 export default class TableWidget extends Widget {
-    //A SORTED array of table keys:frequencies. It is like that for ease of sorting.
-    private tableEntries: [string, number][] = [];
+    //A SORTED array of row indices to numbers
+    private tableEntries: [number, number][] = [];
     private columns: [column: string, columnIndex: number][] = [];
-    private tableRows: JSX.Element[] = []; //pre-computed table rows
     private searchState = '';
     private bouncySearchState = '';
     private pageState = 0;
@@ -130,22 +130,6 @@ export default class TableWidget extends Widget {
                 indices,
                 this.cullEmpty.selected === 'True'
             );
-
-            //Build the DOM objects from the sorted list
-            this.tableRows = [];
-            for (let i = 0; i < this.tableEntries.length; i++) {
-                const key = this.tableEntries[i][0];
-                const freq = this.tableEntries[i][1];
-                const row = (
-                    <tr key={key.split('\0').join('/') + ':' + freq}>
-                        {key.split('\0').map((colVal) => (
-                            <td key={uuidv4()}>{colVal}</td>
-                        ))}
-                        <td>{freq}</td>
-                    </tr>
-                );
-                this.tableRows.push(row);
-            }
         }
 
         //Return the actual sorted table
@@ -172,7 +156,7 @@ export default class TableWidget extends Widget {
                             ? this.pageState +
                               1 +
                               '/' +
-                              (Math.floor(this.tableRows.length / this.pageSize) + 1)
+                              (Math.floor(this.tableEntries.length / this.pageSize) + 1)
                             : '-/-'}
                     </span>
                     {/* PgRight Button */}
@@ -180,10 +164,10 @@ export default class TableWidget extends Widget {
                         className='btn btn-primary lr-button'
                         disabled={
                             this.searchState.trim() !== '' ||
-                            (this.pageState + 1) * this.pageSize >= this.tableRows.length
+                            (this.pageState + 1) * this.pageSize >= this.tableEntries.length
                         }
                         onClick={() => {
-                            if ((this.pageState + 1) * this.pageSize >= this.tableRows.length)
+                            if ((this.pageState + 1) * this.pageSize >= this.tableEntries.length)
                                 return;
                             this.pageState += 1;
                             this.refresh();
@@ -224,8 +208,9 @@ export default class TableWidget extends Widget {
                         }}
                     />
                     <datalist id={this.uuid.toString() + '-search'}>
-                        {this.tableRows.map((row) => {
-                            return <option key={row.key + '-option'} value={row.key} />;
+                        {this.tableEntries.map(([rowIdx, _freq]) => {
+                            const key = this.keyFromRow(rowIdx);
+                            return <option key={key + '-option'} value={key} />;
                         })}
                     </datalist>
                 </div>
@@ -247,77 +232,123 @@ export default class TableWidget extends Widget {
                         {/* If search state is empty, show the paged table.
                             If not, extend the table and just show everything */}
                         {this.searchState.trim() === ''
-                            ? this.tableRows.filter((_row, idx) => {
-                                  return Math.floor(idx / this.pageSize) === this.pageState;
-                              })
-                            : this.tableRows.filter((row) =>
-                                  row.key.toLowerCase().includes(this.searchState.toLowerCase())
-                              )}
+                            ? this.tableEntries
+                                  .filter(
+                                      (_rowFreq, idx) =>
+                                          Math.floor(idx / this.pageSize) === this.pageState
+                                  )
+                                  .map(([key, freq]) => {
+                                      return (
+                                          <tr key={this.keyFromRow(key)}>
+                                              {this.columns.map(([_colName, cIdx]) => (
+                                                  <td key={uuidv4()}>
+                                                      {unpack(
+                                                          this.panel.dataFilterer.getData()[0][key][
+                                                              cIdx
+                                                          ]
+                                                      )}
+                                                  </td>
+                                              ))}
+                                              <td>{freq}</td>
+                                          </tr>
+                                      );
+                                  })
+                            : this.tableEntries
+                                  .filter(([key, _freq]) =>
+                                      this.keyFromRow(key)
+                                          .toLowerCase()
+                                          .includes(this.searchState.toLowerCase())
+                                  )
+                                  .map(([key, freq]) => {
+                                      return (
+                                          <tr
+                                              key={this.columns
+                                                  .map(([_colName, cIdx]) =>
+                                                      unpack(
+                                                          this.panel.dataFilterer.getData()[0][key][
+                                                              cIdx
+                                                          ]
+                                                      )
+                                                  )
+                                                  .join('/')}
+                                          >
+                                              {this.columns.map(([_colName, cIdx]) => (
+                                                  <td key={uuidv4()}>
+                                                      {unpack(
+                                                          this.panel.dataFilterer.getData()[0][key][
+                                                              cIdx
+                                                          ]
+                                                      )}
+                                                  </td>
+                                              ))}
+                                              <td>{freq}</td>
+                                          </tr>
+                                      );
+                                  })}
                     </tbody>
                 </table>
             </div>
         );
     }
 
+    private keyFromRow(rowIdx: number) {
+        return this.columns
+            .map(([_colName, cIdx]) => unpack(this.panel.dataFilterer.getData()[0][rowIdx][cIdx]))
+            .join('/');
+    }
+
+    /**
+     * When given some filtered data from panel.dataFilterer, this will
+     * calculate the unique rows (of indices) along with their frequencies
+     * @param data panel.dataFilterer.getData()[0]
+     * @param dataLength panel.dataFilterer.getData()[1]
+     * @param indices Column indices of the columns that you want to include
+     * @param cullEmpty Whether or not to ignore rows that contain [none] in the
+     * supplied indices
+     * @returns An array of [number,number][], where the first index of each
+     * array entry is the row index in panel.dataFilterer.getData, and the
+     * second index is the frequency that the row appears in
+     */
     protected static processAsArray(
         data: (string | number | SetElement)[][],
         dataLength: number,
         indices: number[],
         cullEmpty: boolean
-    ): [string, number][] {
-        // Write rows as strings
-        // Order the strings
-        // Collect same strings, they're consecutive
-        // Sort by frequency
+    ): [number, number][] {
+        // Sort the rows according to the input indices
+        // Iterate the rows in one pass and count identical rows,
+        // as they will be grouped together
+        // Sort by frequency at the end
 
-        const arr = [],
-            indicesLength = indices.length;
+        // don't bother with calculations
+        if (dataLength === 0) return [];
 
-        // Rows as strings
+        //[0,1,2...,dataLength]
+        const sortedArray = [...Array(dataLength).keys()];
 
-        // variable "row" reused inside loop
-        const row = new Array(indicesLength);
-        nextRow: for (let i = 0; i < dataLength; i++) {
-            const dataRow = data[i];
-            for (let x = 0; x < indicesLength; x++) {
-                const val = dataRow[indices[x]];
-                if (val instanceof SetElement) row[x] = val.value;
-                else row[x] = val;
-                // issue #91: skip or not (Do not skip)
-                if (cullEmpty)
-                    if (row[x] === '[none]')
-                        continue nextRow;
-            }
-            arr.push(row.join('\0'));
-        }
+        // Order the array by the selected columns
+        sortedArray.sort((id1, id2) => rowComparator(data, indices, id1, id2));
 
-        const arrLength = arr.length;
-
-        // needed for the loop later
-        if (arrLength == 0) return [];
-
-        // Order the strings
-        arr.sort();
-
-        // Collect same strings, they're consecutive
-        //Potential optimisation to build the DOM straight in here
-        const newArr = [];
-        let old: string = arr[0],
+        // Collect same data rows, they're consecutive
+        const groupedArray = [];
+        let old: number = sortedArray[0],
             oldCount: number = 1;
-        for (let i = 1; i < arrLength; i++) {
-            if (arr[i] == old) {
+        for (let i = 1; i < sortedArray.length; i++) {
+            if (rowComparator(data, indices, sortedArray[i], old) === 0) {
                 oldCount++;
             } else {
-                newArr.push([old, oldCount]);
-                old = arr[i];
+                //If the row contains blanks, cull it if necessary
+                if (!cullEmpty || !hasEmpty(data[old], indices)) groupedArray.push([old, oldCount]);
+                old = sortedArray[i];
                 oldCount = 1;
             }
         }
-        newArr.push([old, oldCount]);
-        arr.length = 0;
-        newArr.sort((a, b) => b[1] - a[1]);
+        //Remember to check again here
+        if (!cullEmpty || !hasEmpty(data[old], indices)) groupedArray.push([old, oldCount]);
 
-        return newArr;
+        groupedArray.sort((a, b) => b[1] - a[1]);
+
+        return groupedArray;
     }
 
     public delete(): void {

--- a/devfiles/src/classes/widgets/TableWidget.tsx
+++ b/devfiles/src/classes/widgets/TableWidget.tsx
@@ -309,7 +309,7 @@ export default class TableWidget extends Widget {
      * array entry is the row index in panel.dataFilterer.getData, and the
      * second index is the frequency that the row appears in
      */
-    protected static processAsArray(
+    public static processAsArray(
         data: (string | number | SetElement)[][],
         dataLength: number,
         indices: number[],

--- a/devfiles/src/utils/DataUtils.test.ts
+++ b/devfiles/src/utils/DataUtils.test.ts
@@ -1,0 +1,60 @@
+import ReferenceSet from '../classes/data/setutils/ReferenceSet.js';
+import SetElement from '../classes/data/setutils/SetElement.js';
+import { hasEmpty, rowComparator, unpack } from './DataUtils.js';
+
+describe('DataUtils', () => {
+    const refSet: ReferenceSet = new ReferenceSet();
+    it('hasEmpty returns true if an empty element is present in the indices', () => {
+        expect(
+            hasEmpty([33, refSet.addRawOrGet('aa'), 112, refSet.addRawOrGet('[none]')], [0, 3])
+        ).toStrictEqual(true);
+        expect(
+            hasEmpty([refSet.addRawOrGet('[none]'), refSet.addRawOrGet('[none]')], [0, 1])
+        ).toStrictEqual(true);
+        expect(hasEmpty(['[none]', 1, 2, 3], [0])).toStrictEqual(true);
+        expect(
+            hasEmpty([refSet.addRawOrGet('[warning]'), '[none]', 1, 2, 3], [0, 1, 2, 3, 4])
+        ).toStrictEqual(true);
+    });
+    it('hasEmpty returns false if an empty element is not present in the indices', () => {
+        expect(
+            hasEmpty(
+                ['asdasd', 'udfhaslk', 112, refSet.addRawOrGet('sdajkf'), refSet.addRawOrGet('aa')],
+                [0, 3]
+            )
+        ).toStrictEqual(false);
+        expect(
+            hasEmpty([refSet.addRawOrGet('[warning]'), '[none]', 1, 2, 3], [0, 2, 3, 4])
+        ).toStrictEqual(false);
+    });
+    it('unpack returns the correct values', () => {
+        expect(unpack(refSet.addRawOrGet('hello'))).toStrictEqual('hello');
+        expect(unpack(refSet.addRawOrGet('9821u90u9efwijolksadf!'))).toStrictEqual(
+            '9821u90u9efwijolksadf!'
+        );
+        expect(unpack('normal')).toStrictEqual('normal');
+        expect(unpack(11)).toStrictEqual(11);
+    });
+
+    it('rowComparator can properly sort rows', () => {
+        //Assert: row1 > row2 > row3 > row4 == row5
+        const row1 = [refSet.addRawOrGet('zdajkf'), 12312, 'haha'];
+        const row2 = [refSet.addRawOrGet('sdajkf'), 12312, 'haha'];
+        const row3 = [refSet.addRawOrGet('sdajkf'), 12303, 'zaha'];
+        const row4 = [refSet.addRawOrGet('sdajkf'), 12303, 'haha'];
+        const row5 = [refSet.addRawOrGet('sdajkf'), 12303, 'haha'];
+        const data = [row5, row3, row2, row1, row4];
+        const toBeSorted = [0, 1, 2, 3, 4].sort((id1, id2) =>
+            rowComparator(data, [0, 1, 2], id1, id2)
+        );
+
+        expect(rowComparator(data, [0, 1, 2], 0, 4), 'Equality test').toStrictEqual(0);
+        expect(rowComparator(data, [0, 1, 2], 3, 2), 'Greater than test').toStrictEqual(1);
+
+        expect(data[toBeSorted[0]], 'sorted index 0').toStrictEqual(row5);
+        expect(data[toBeSorted[1]], 'sorted index 1').toStrictEqual(row4);
+        expect(data[toBeSorted[2]], 'sorted index 2').toStrictEqual(row3);
+        expect(data[toBeSorted[3]], 'sorted index 3').toStrictEqual(row2);
+        expect(data[toBeSorted[4]], 'sorted index 4').toStrictEqual(row1);
+    });
+});

--- a/devfiles/src/utils/DataUtils.test.ts
+++ b/devfiles/src/utils/DataUtils.test.ts
@@ -37,6 +37,10 @@ describe('DataUtils', () => {
     });
 
     it('rowComparator can properly sort rows', () => {
+        const row01 = [12312, 'haha'];
+        const row02 = [12313, 'haha'];
+        expect(rowComparator([row01, row02], [0, 1], 0, 1), 'Number Comparison').toStrictEqual(-1);
+
         //Assert: row1 > row2 > row3 > row4 == row5
         const row1 = [refSet.addRawOrGet('zdajkf'), 12312, 'haha'];
         const row2 = [refSet.addRawOrGet('sdajkf'), 12312, 'haha'];

--- a/devfiles/src/utils/DataUtils.ts
+++ b/devfiles/src/utils/DataUtils.ts
@@ -1,0 +1,33 @@
+import SetElement from '../classes/data/setutils/SetElement';
+
+function hasEmpty(row: (string | number | SetElement)[], indices: number[]) {
+    for (const i of indices) {
+        if (unpack(row[i]) === '[none]') return true;
+    }
+    return false;
+}
+
+function unpack(i: SetElement | string | number): string | number {
+    if (typeof i === 'object') return (i as SetElement).value;
+    return i;
+}
+
+function rowComparator(
+    data: (string | number | SetElement)[][],
+    indices: number[],
+    rowId1: number,
+    rowId2: number
+): number {
+    const row1 = data[rowId1];
+    const row2 = data[rowId2];
+
+    for (const colId of indices) {
+        const cell1 = unpack(row1[colId]);
+        const cell2 = unpack(row2[colId]);
+        if (cell1 === cell2) continue;
+        return [cell1, cell2].sort()[0] === cell1 ? -1 : 1;
+    }
+    return 0;
+}
+
+export { rowComparator, unpack, hasEmpty };

--- a/devfiles/src/utils/generateHash.ts
+++ b/devfiles/src/utils/generateHash.ts
@@ -1,4 +1,6 @@
-export default function generateHash(a: number, b: number) {
+export default function generateHash(...inp: number[]) {
     //(prime*a)+b is a hash of (a,b)
-    return 23629 * a + b;
+    let agg = 0;
+    inp.forEach((i) => (agg = 23629 * agg + i));
+    return agg;
 }


### PR DESCRIPTION
- Optimising tables to stop creating monster strings everywhere
- Almost fast enough to handle grouping the whole column set, but building the search index above the table kills performance (it creates monster strings)
- Refactored unrelated methods from TableWidget into a new utility function exporter DataUtils
- Wrote tests for the static methods in TableWidget and the new utility function exporter