### PR TITLE
Fix issues by modifying chart options

### DIFF
--- a/devfiles/src/classes/options/Selector.tsx
+++ b/devfiles/src/classes/options/Selector.tsx
@@ -13,6 +13,7 @@ export default class Selector extends InputOption {
     public excluded: Set<string> = new Set();
     public readonly columnIndex;
     private accordionOpen = false;
+    public useSearchBar: boolean = true;
 
     /**
      * @param panel The associated panel
@@ -77,7 +78,7 @@ export default class Selector extends InputOption {
         //If there are more than 5 selections, enable advanced options
         // like search
         let searchBar = <></>;
-        if (this.choices.size > 5) {
+        if (this.choices.size > 5 && this.useSearchBar) {
             searchBar = (
                 <div style={{ paddingBottom: '5px' }}>
                     <input

--- a/devfiles/src/classes/widgets/BarChart.tsx
+++ b/devfiles/src/classes/widgets/BarChart.tsx
@@ -8,6 +8,7 @@ import {
     DayGrouping,
     FilenameGrouping,
     Grouping,
+    HourGrouping,
     MonthGrouping,
     ProjectNameGrouping,
     YGrouping,
@@ -26,6 +27,7 @@ export default class BarChart extends TimeChart {
     }
     public timeRangeGroupings(): (typeof Grouping)[] {
         return [
+            HourGrouping,
             DayGrouping,
             MonthGrouping,
             YearGrouping,

--- a/devfiles/src/classes/widgets/Grouping.test.ts
+++ b/devfiles/src/classes/widgets/Grouping.test.ts
@@ -226,6 +226,62 @@ describe('Grouping', async () => {
                 }
             }
         });
+        describe('test on expected examples', () => {
+            beforeEach(async () => {
+                data = await loadData(filename3);
+                filter = new DataFilterer(data);
+            });
+            [
+                {
+                    xGrouping: BatchNameGrouping,
+                    yGrouping: YGrouping.Species,
+                    expected: [
+                        ['scotland pam', 'clanga clanga', 4],
+                        ['scotland pam', 'cygnus olor', 2],
+                        ['scotland pam', 'barbitistes serricauda', 2],
+                        ['scotland pam', 'barbitistes fischeri', 2]
+                    ]
+                },
+                {
+                    xGrouping: DayGrouping,
+                    yGrouping: YGrouping.VulnerabilityStatus,
+                    expected: [
+                        ['01-08-23', 'vulnerable', 4],
+                        ['01-08-23', 'least concern', 2],
+                        ['02-08-23', 'least concern', 4]
+                    ]
+                },
+                {
+                    xGrouping: HourGrouping,
+                    yGrouping: YGrouping.SpeciesGroup,
+                    expected: [
+                        ['06:00', 'insects', 1],
+                        ['07:00', 'insects', 1],
+                        ['12:00', 'insects', 2],
+                        ['10:00', 'birds', 3],
+                        ['12:00', 'birds', 1],
+                        ['18:00', 'birds', 1],
+                        ['21:00', 'birds', 1]
+                    ]
+                }
+            ].forEach(({ xGrouping, yGrouping, expected }) => {
+                it(`should aggregate pairs for ${xGrouping} and ${yGrouping}`, () => {
+                    const grouping = new xGrouping(filter, yGrouping);
+                    const aggregated = grouping.aggregatePairs();
+                    for (const [y, xMap] of aggregated) {
+                        for (const [x, count] of xMap) {
+                            if (count != 0) {
+                                expect(expected).toContainEqual([
+                                    x.value.toLowerCase(),
+                                    y.value.toLowerCase(),
+                                    count
+                                ]);
+                            }
+                        }
+                    }
+                });
+            });
+        });
     });
     describe('xValueMap', () => {
         [

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -21,6 +21,7 @@ abstract class Grouping {
     yColumnIdx: number;
     yGrouping: YGrouping;
     speciesMeta: SpeciesMeta;
+    static maxXValues: number = 1000;
     constructor(filter: DataFilterer, yGrouping: YGrouping) {
         this.filter = filter;
         this.referenceSet = new ReferenceSet();

--- a/devfiles/src/classes/widgets/TimeChart.tsx
+++ b/devfiles/src/classes/widgets/TimeChart.tsx
@@ -35,6 +35,8 @@ export default abstract class TimeChart extends Widget {
             Object.values(YGrouping)
         );
 
+        this.xAxisSelector.useSearchBar = false;
+        this.yAxisSelector.useSearchBar = false;
         // Refresh widgets when options are change.
         this.xAxisSelector.extendedCallbacks.push(() => {
             this.refresh();

--- a/devfiles/src/classes/widgets/TimeChart.tsx
+++ b/devfiles/src/classes/widgets/TimeChart.tsx
@@ -27,7 +27,8 @@ export default abstract class TimeChart extends Widget {
         super(panel, config);
         this.generateOptions();
     }
-    public generateOptions(): void {
+    public async generateOptions(): Promise<void> {
+        // The filteringn is slow so this is made async to reduce user wait time.
         const filter = this.panel.dataFilterer;
         const groupings = this.timeRangeGroupings()
             .filter((grouping) => {


### PR DESCRIPTION
This fixes:
- #195 
- #200 
- get rid of search bar from bar chart options

I've made the options generation async because manually running the filtering is slow. This might not be the best way.