### PR TITLE
Filename grouping -> csv name

### DIFF
--- a/devfiles/src/classes/widgets/Grouping.test.ts
+++ b/devfiles/src/classes/widgets/Grouping.test.ts
@@ -32,7 +32,7 @@ describe('Grouping', async () => {
     describe('selectByColumn', () => {
         it('should select values by column', () => {
             const grouping = new BatchNameGrouping(filter, YGrouping.Species);
-            const columnIdx = filter.getColumnIndex(Attribute.originalFileName);
+            const columnIdx = filter.getColumnIndex(Attribute.csvName);
             const [dataSubset, _] = filter.getData();
             const values = dataSubset.map((row) => grouping.selectByColumnIndex(row, columnIdx));
             for (const v1 of values) {
@@ -51,7 +51,7 @@ describe('Grouping', async () => {
         [
             {
                 grouping: FilenameGrouping,
-                attribute: Attribute.originalFileName
+                attribute: Attribute.csvName
             },
             {
                 grouping: ProjectNameGrouping,
@@ -295,7 +295,7 @@ describe('Grouping', async () => {
             },
             {
                 grouping: FilenameGrouping,
-                attribute: Attribute.originalFileName
+                attribute: Attribute.csvName
             },
             {
                 grouping: YearGrouping,

--- a/devfiles/src/classes/widgets/Grouping.ts
+++ b/devfiles/src/classes/widgets/Grouping.ts
@@ -220,7 +220,7 @@ class FilenameGrouping extends Grouping {
     columnIdx: number;
     constructor(filter: DataFilterer, yGrouping: YGrouping) {
         super(filter, yGrouping);
-        this.columnIdx = filter.getColumnIndex(Attribute.originalFileName);
+        this.columnIdx = filter.getColumnIndex(Attribute.csvName);
     }
     public selectX(row: Row): SetElement {
         return this.selectByColumnIndex(row, this.columnIdx);


### PR DESCRIPTION
Apparently filename grouping was broken because every row has a unique recording file name, but we can group by csv name instead which would be more useful

CC @George-Ogden 