### PR TITLE
Table no longer crashes on bad column picks

### DIFF
--- a/devfiles/src/ui/PanelComp.tsx
+++ b/devfiles/src/ui/PanelComp.tsx
@@ -77,7 +77,10 @@ function PanelComp(params: { panelIdx: number; pageManager: PageManager }) {
 
     function selectThisPanel() {
         //If there is a previous selected panel, render unselection
-        if (params.pageManager.unselectPanel) {
+        if (
+            params.pageManager.unselectPanel &&
+            params.pageManager.selectedPanel !== params.panelIdx
+        ) {
             //Ensure previous widget is unselected
             params.pageManager.selectedWidget = -1;
             if (params.pageManager.unselectWidget) params.pageManager.unselectWidget();

--- a/devfiles/src/ui/WidgetComp.tsx
+++ b/devfiles/src/ui/WidgetComp.tsx
@@ -17,8 +17,6 @@ function WidgetComp(params: {
     const widget = panel.getWidget(params.widgetIdx);
     widget.refresh = () => dud(r + 1);
 
-    console.log('Rendering widget', widget.uuid, 'under panel', panel.uuid);
-
     return params.widgetClass.render();
 }
 


### PR DESCRIPTION
- Bootstrap's search indexer will no longer be active past 5000 rows. 
- Additionally, panels no longer de-select themselves when clicked